### PR TITLE
Updating for Puppet 4.7

### DIFF
--- a/manifests/https.pp
+++ b/manifests/https.pp
@@ -20,10 +20,6 @@
 #   The host/port to forward requests to.
 #   Default: { '127.0.0.1' => '80' }
 #
-# [*ensure*]
-#   Ensure this entry is present or absent.
-#   Default: present
-#
 # [*target*]
 #   The config file to update.
 #   Default: /etc/pound.cfg
@@ -49,7 +45,6 @@ define pound::https (
   $address          = $::ipaddress,
   $port             = '443',
   $backend          = { '127.0.0.1' => '80' },
-  $ensure           = 'present',
   $target           = '/etc/pound.cfg',
   $custom_template  = undef,
   $ciphers          = 'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;',
@@ -66,7 +61,6 @@ define pound::https (
     
   concat::fragment { "https_server-${title}":
     order   => "20-${title}",
-    ensure  => $ensure,
     target  => $target,
     content => $content,
   }

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">=3.2.0 <3.4.0"
+      "version_requirement": ">=2017.1.0"
     },
     {
       "name": "puppet",
-      "version_requirement": ">=3.0.0 <4.0.0"
+      "version_requirement": ">=4.7.0"
     }
   ],
   "dependencies": [
@@ -24,7 +24,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0 <2.0.0"
+      "version_requirement": ">= 4.0.0"
     }
   ],
   "types": [
@@ -34,13 +34,13 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6"
+        "6", "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6"
+        "6", "7"
       ]
     }
   ]


### PR DESCRIPTION
- requiring Puppet >= 4.7.0 or PE >= 2017.1.0
- requiring puppetlabs-concat >= 4.0.0
- removing pound::https::ensure parameter
- removing concat::fragment::ensure parameter

This change allows use with the current puppetlabs-concat 4.0.0. Unfortunately, it requires Puppet >= 4.7.0, breaking older versions.  This may require a major version bump on the pound module.
