### PR TITLE
Small fix for Debian installations

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,6 @@
 ---
 pound::package_ensure: present
-pound::package_name: Pound
+pound::package_name: pound
 pound::service_ensure: running
 pound::service_manage: true
 pound::config_file: /etc/pound.cfg

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@
 # Copyright 2017 Adam Crews, unless otherwise noted.
 #
 # @param package_ensure Ensure the package is either present or absent. Default: present
-# @param package_name The name of the package to install. Default: Pound
+# @param package_name The name of the package to install. Default: pound
 # @param service_ensure Ensure the service is running or stopped.  Default: running
 # @param service_manage Manage the state of the service or not.  Default: true
 # @param config_name The path to the config file.  Default: /etc/pound.cfg


### PR DESCRIPTION
The package installation on Debian does not work, because the package 'Pound' does not exists. It is called 'pound' (lowercase p).

The result of the current version is:
```
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install Pound' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package Pound
Error: /Stage[main]/Pound::Install/Package[pound]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install Pound' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package Pound
```

This can be verified manually:

```
# /usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install Pound
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package Pound
```

While lowercase does work:

```
# /usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install pound
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  pound
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 108 kB of archives.
After this operation, 212 kB of additional disk space will be used.
Get:1 http://mirror.duocast.net/debian stretch/main amd64 pound amd64 2.7-1.3 [108 kB]
Fetched 108 kB in 0s (2,964 kB/s)
Selecting previously unselected package pound.
(Reading database ... 42731 files and directories currently installed.)
Preparing to unpack .../pound_2.7-1.3_amd64.deb ...
Unpacking pound (2.7-1.3) ...
Processing triggers for systemd (232-25+deb9u1) ...
Processing triggers for man-db (2.7.6.1-2) ...
Setting up pound (2.7-1.3) ...
Processing triggers for systemd (232-25+deb9u1) ...
```
