### PR TITLE
Allow puppetlabs-concat < 6.0.0, puppetlabs-stdlib < 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This will allow use with current modules from Puppet Forge.